### PR TITLE
(no merge) Keep 1.9.x as a branch

### DIFF
--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -2,9 +2,9 @@
 # https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
 FROM httpd:2.4.25@sha256:0d817a924bed1a216f12a0f4947b5f8a2f173bd5a9cebfe1382d024287154c99
 
-ENV SVN_VERSION 1.8.17
+ENV SVN_VERSION 1.9.5
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
-ENV SVN_BZ2_SHA1 0999f5e16b146f824b952a5552826b9cb5c47b13
+ENV SVN_BZ2_SHA1 8bd6a44a1aed30c4c6b6b068488dafb44eaa6adf
 
 RUN depsRuntime=' \
 		libsqlite3-0 \

--- a/rweb/fpm-svn/Dockerfile
+++ b/rweb/fpm-svn/Dockerfile
@@ -3,9 +3,9 @@ FROM php:7.0.14-fpm
 # Same build concept as in httpd,
 # but rweb should only have the svn client with http ra
 
-ENV SVN_VERSION 1.8.17
+ENV SVN_VERSION 1.9.5
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
-ENV SVN_BZ2_SHA1 0999f5e16b146f824b952a5552826b9cb5c47b13
+ENV SVN_BZ2_SHA1 8bd6a44a1aed30c4c6b6b068488dafb44eaa6adf
 
 RUN buildDeps=' \
     ca-certificates \

--- a/svnclient/Dockerfile
+++ b/svnclient/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:jessie@sha256:f7062cf040f67f0c26ff46b3b44fe036c29468a7e69d8170f37c57f2eec1261b
 
-ENV SVN_VERSION 1.8.17
+ENV SVN_VERSION 1.9.5
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
-ENV SVN_BZ2_SHA1 0999f5e16b146f824b952a5552826b9cb5c47b13
+ENV SVN_BZ2_SHA1 8bd6a44a1aed30c4c6b6b068488dafb44eaa6adf
 
 RUN depsRuntime=' \
 		libsqlite3-0 \


### PR DESCRIPTION
Sequel to #6

Built as ´:1.9´ in https://hub.docker.com/r/solsson/svn-httpd/ and https://hub.docker.com/r/solsson/svn-httpd-proxied/. Also note that the deprecated `solsson/svn-httpd:proxied` will stay on 1.9 because repositories created with it will not be compatible with 1.8.
