### PR TITLE
Add svn client http+https support to httpd image

### DIFF
--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -7,14 +7,14 @@ services:
     expose:
       - "80"
 
-  svn_adminrest:
+  svn-adminrest:
     build: ../httpd
     environment:
       ADMIN_REST_ACCESS: "true"
     expose:
       - "80"
 
-  svn_authz:
+  svn-authz:
     build: ../httpd
     environment:
       ADMIN_REST_ACCESS: "true"
@@ -71,7 +71,7 @@ services:
       com.yolean.build-contract: "*"
     links:
       - svn
-      - svn_adminrest
+      - svn-adminrest
 
   httpd-curl:
     build: ../httpd

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -59,13 +59,13 @@ services:
     links:
       - rweb-httpd:svn
 
-  debian-svnclient:
-    build: ../debian-svnclient
-    image: solsson/debian-svnclient
+  svnclient:
+    build: ../svnclient
+    image: solsson/svnclient
 
   svntest:
     depends_on:
-      - debian-svnclient
+      - svnclient
     build: ./svntest
     labels:
       com.yolean.build-contract: "*"

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -73,9 +73,16 @@ services:
       - svn
       - svn_adminrest
 
+  httpd-svn-curl:
+    build: ../httpd
+    labels:
+      - com.yolean.build-contract
+    entrypoint: curl
+    command: [-I, "https://svn.apache.org/repos/asf/subversion/trunk/"]
+
   httpd-svn-client:
     build: ../httpd
     labels:
       - com.yolean.build-contract
     entrypoint: svn
-    command: [info, "https://github.com/Reposoft/docker-svn"]
+    command: [info, "https://svn.apache.org/repos/asf/subversion/trunk/"]

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -73,16 +73,16 @@ services:
       - svn
       - svn_adminrest
 
-  httpd-svn-curl:
+  httpd-curl:
     build: ../httpd
     labels:
       - com.yolean.build-contract
     entrypoint: curl
-    command: [-I, "https://svn.apache.org/repos/asf/subversion/trunk/"]
+    command: [-I, "https://svn.apache.org/repos/asf/subversion/trunk/", "-k"]
 
   httpd-svn-client:
     build: ../httpd
     labels:
       - com.yolean.build-contract
     entrypoint: svn
-    command: [info, "https://svn.apache.org/repos/asf/subversion/trunk/"]
+    command: [info, "https://svn.apache.org/repos/asf/subversion/trunk/", "--trust-server-cert"]

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -72,3 +72,10 @@ services:
     links:
       - svn
       - svn_adminrest
+
+  httpd-svn-client:
+    build: ../httpd
+    labels:
+      - com.yolean.build-contract
+    entrypoint: svn
+    command: [info, "https://github.com/Reposoft/docker-svn"]

--- a/build-contracts/svntest/Dockerfile
+++ b/build-contracts/svntest/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM solsson/debian-svnclient
+FROM solsson/svnclient
 
 COPY . /test/
 

--- a/build-contracts/svntest/repocreate.sh
+++ b/build-contracts/svntest/repocreate.sh
@@ -4,11 +4,11 @@ set -e
 
 [[ -z "$RETRY" ]] && RETRY="--retry 3 --retry-delay 5"
 
-curl $RETRY -f http://svn_adminrest/svn/ -I || exit 1
+curl $RETRY -f http://svn-adminrest/svn/ -I || exit 1
 
-curl $RETRY -f http://svn_adminrest/admin/repocreate -d reponame=test1 || exit 1
+curl $RETRY -f http://svn-adminrest/admin/repocreate -d reponame=test1 || exit 1
 
-curl $RETRY -f http://svn_adminrest/svn/test1/ -I || exit 1
+curl $RETRY -f http://svn-adminrest/svn/test1/ -I || exit 1
 
 #noaccess=$(curl $RETRY -f http://svn_noadminrest/admin/repocreate -I)
 #echo $noaccess

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -8,8 +8,12 @@ ENV SVN_BZ2_SHA1 0999f5e16b146f824b952a5552826b9cb5c47b13
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# we have the stretch package repo from upstream, so let's use https://packages.debian.org/stretch/ca-certificates
+ENV CA_CERTIFICATES_VERSION 20161130
+
 RUN depsRuntime=" \
 		libsqlite3-0 \
+		ca-certificates=$CA_CERTIFICATES_VERSION \
 		curl \
 		libserf-1-1 \
 	" \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -13,7 +13,6 @@ ENV CA_CERTIFICATES_VERSION 20161130
 
 RUN depsRuntime=" \
 		libsqlite3-0 \
-		ca-certificates=$CA_CERTIFICATES_VERSION \
 		curl \
 		libserf-1-1 \
 	" \
@@ -33,7 +32,6 @@ RUN depsRuntime=" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $depsRuntime \
 	&& apt-get install -y --no-install-recommends $depsBuild \
-	&& rm -r /var/lib/apt/lists/* \
 	&& curl -SL "$SVN_BZ2_URL" -o subversion-$SVN_VERSION.tar.bz2 \
 	&& echo "$SVN_BZ2_SHA1 subversion-$SVN_VERSION.tar.bz2" | sha1sum -c - \
 	&& mkdir -p src/svn \
@@ -47,6 +45,8 @@ RUN depsRuntime=" \
 	&& cd ../../ \
 	&& rm -r src/svn \
 	&& apt-get purge -y --auto-remove $depsBuild \
+	&& apt-get install -y ca-certificates=$CA_CERTIFICATES_VERSION \
+	&& rm -r /var/lib/apt/lists/* \
 	&& echo "Include conf/svn/httpd.conf" >> conf/httpd.conf
 
 COPY conf conf/svn

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -21,7 +21,7 @@ RUN depsRuntime=" \
 		libssl-dev=$OPENSSL_VERSION \
 		make \
 		libsqlite3-dev \
-		libz-dev \
+		zlib1g-dev \
 		libneon27-dev \
 		libserf-dev \
 	" \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN depsRuntime=" \
 		libsqlite3-0 \
 		curl \
+		libserf-1-1 \
 	" \
 	&& depsBuild=" \
 		ca-certificates \
@@ -21,6 +22,8 @@ RUN depsRuntime=" \
 		make \
 		libsqlite3-dev \
 		libz-dev \
+		libneon27-dev \
+		libserf-dev \
 	" \
 	set -x \
 	&& apt-get update \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -8,12 +8,8 @@ ENV SVN_BZ2_SHA1 0999f5e16b146f824b952a5552826b9cb5c47b13
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# we have the stretch package repo from upstream, so let's use https://packages.debian.org/stretch/ca-certificates
-ENV CA_CERTIFICATES_VERSION 20161130
-
 RUN depsRuntime=" \
 		libsqlite3-0 \
-		ca-certificates=$CA_CERTIFICATES_VERSION \
 		curl \
 		libserf-1-1 \
 	" \

--- a/httpd/conf/httpd.conf
+++ b/httpd/conf/httpd.conf
@@ -6,7 +6,7 @@ Include conf/svn/load.conf
 <IfDefine AUTHZ=inrepo>
   Include conf/svn/load-authz.conf
 </IfDefine>
-<IfDefine AUTHZ=admin>
+<IfDefine AUTHZ=admrepo>
   Include conf/svn/load-authz.conf
 </IfDefine>
 


### PR DESCRIPTION
Good for admin tasks like svnsync.

Currently fails to validate server certificates. Tried but reverted https://github.com/Reposoft/docker-svn/commit/c13dd55c77df869856eea92143857d2ba4772860.