### PR TITLE
Use debian:stretch-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 # Dummy dockerfile for https://github.com/Yolean/build-contract/blob/b37695903e05ee56afba5936f9ce51ea5c559e88/build-contract#L5
-FROM debian:stretch-slim
+FROM debian:stretch-slim@sha256:ea42520331a55094b90f6f6663211d4f5a62c5781673935fe17a4dfced777029

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 # Dummy dockerfile for https://github.com/Yolean/build-contract/blob/b37695903e05ee56afba5936f9ce51ea5c559e88/build-contract#L5
-FROM debian:jessie
+FROM debian:stretch-slim

--- a/README.md
+++ b/README.md
@@ -13,22 +13,24 @@ Our next best bet would be something like [IPFS](https://ipfs.io/), but we're in
 
 ## [solsson/svn-httpd](https://hub.docker.com/r/solsson/svn-httpd/)
 
-Runtime configuration:
+Runtime configuration, as environment variables:
  * `ADMIN_REST_ACCESS` non-empty to enable `/admin/repocreate` REST endpoint
- * `AUTHN`=`anon` enables [mod_auth_anon] so that usernames from reverse proxy end up in svn logs
- * `AUTHZ`=`svn` enables [mod_autnz_svn] with path `/svn/aunhz`
- * `RWEB`=`fpm` is used from `solsson/rweb-httpd` (see below) to enable rweb config directives
+
+Runtime configuration, as [CMD](https://docs.docker.com/engine/reference/builder/#cmd) override:
+ * `-DAUTHN=anon` enables [mod_auth_anon](http://httpd.apache.org/docs/current/mod/mod_authn_anon.html) so that usernames from reverse proxy end up in svn logs
+ * `-DAUTHZ=svn` enables [mod_autnz_svn](http://svnbook.red-bean.com/nightly/en/svn.serverconfig.httpd.html#svn.serverconfig.httpd.ref.mod_authz_svn) with path `/svn/aunhz`
+ * `-DRWEB=fpm` is used from `solsson/rweb-httpd` (see below) to enable rweb config directives
 
 ### The `/r` Location alongside `/svn`
 
 For content hosting you may want to keep URLs backend-neutral.
 For that purpose this image will expose `/r` as read-only variant of `/svn`.
-This is done only if `AUTHN`=`anon`, where it's up to the reverse proxy to expose `/r` or not.
+This is done only if `-DAUTHN=anon`, where it's up to the reverse proxy to expose `/r` or not.
 Also we only enable this with `RWEB`.
 
 ### `solsson/svn-httpd:proxied`
 
-Deprecated. Use `AUTHN`=`anon` instead.
+Deprecated. Use `-DAUTHN=anon` instead.
 
 ## [solsson/rweb](https://hub.docker.com/r/solsson/rweb/)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Runtime configuration, as environment variables:
 
 Runtime configuration, as [CMD](https://docs.docker.com/engine/reference/builder/#cmd) override:
  * `-DAUTHN=anon` enables [mod_auth_anon](http://httpd.apache.org/docs/current/mod/mod_authn_anon.html) so that usernames from reverse proxy end up in svn logs
- * `-DAUTHZ=svn` enables [mod_autnz_svn](http://svnbook.red-bean.com/nightly/en/svn.serverconfig.httpd.html#svn.serverconfig.httpd.ref.mod_authz_svn) with path `/svn/aunhz`
+ * `-DAUTHZ=svn` enables [mod_autnz_svn](http://svnbook.red-bean.com/nightly/en/svn.serverconfig.httpd.html#svn.serverconfig.httpd.ref.mod_authz_svn) with path `/svn/authz`
  * `-DRWEB=fpm` is used from `solsson/rweb-httpd` (see below) to enable rweb config directives
 
 ### The `/r` Location alongside `/svn`

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -18,7 +18,7 @@ RUN depsRuntime=" \
 		bzip2 \
 		gcc \
 		libpcre++-dev \
-		libssl-dev=$OPENSSL_VERSION \
+		libssl-dev \
 		make \
 		libsqlite3-dev \
 		zlib1g-dev \

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,8 +1,8 @@
 
-FROM solsson/httpd-stretch@sha256:5e5359fd904cf2436b6b6811523cf3f0a0bb89eeaa62c667b6d7df901f25d06e
+FROM httpd:2.4.37@sha256:a613d8f1dbb35b18cdf5a756d2ea0e621aee1c25a6321b4a05e6414fdd3c1ac1
 
 ENV SVN_VERSION 1.8.19
-ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
+ENV SVN_BZ2_URL https://archive.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
 ENV SVN_BZ2_SHA1 51d7e5329ad86a650f8fc806eb68e581055a3fd1
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -7,12 +7,10 @@ ENV SVN_BZ2_SHA1 51d7e5329ad86a650f8fc806eb68e581055a3fd1
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# we have the stretch package repo from upstream, so let's use https://packages.debian.org/stretch/ca-certificates
-ENV CA_CERTIFICATES_VERSION 20161130
-
 RUN depsRuntime=" \
 		libsqlite3-0 \
 		curl \
+		ca-certificates \
 		libserf-1-1 \
 	" \
 	&& depsBuild=" \
@@ -44,7 +42,6 @@ RUN depsRuntime=" \
 	&& cd ../../ \
 	&& rm -r src/svn \
 	&& apt-get purge -y --auto-remove $depsBuild \
-	&& apt-get install -y ca-certificates=$CA_CERTIFICATES_VERSION \
 	&& rm -r /var/lib/apt/lists/* \
 	&& echo "Include conf/svn/httpd.conf" >> conf/httpd.conf
 
@@ -57,17 +54,18 @@ RUN ln -s $(pwd)/admin-cgi/repocreate /usr/local/bin/repocreate
 
 # Set to non-empty to enable /admin/repocreate http endpoint
 ENV ADMIN_REST_ACCESS ""
-# Set to "anon" to pick up username (for commit log etc) from BASIC auth header without verification of credentials
-ENV AUTHN ""
-# Set to "svn"/"inrepo"/"admrepo", see conf/authz/options.conf
-ENV AUTHZ ""
-# Set to "fpm" to enable rweb conf
-ENV RWEB ""
-
-# Allow IfDefine based on container runtime env
-RUN sed -i 's/-DFOREGROUND/-DFOREGROUND -DAUTHN=$AUTHN -DAUTHZ=$AUTHZ -DRWEB=$RWEB/' /usr/local/bin/httpd-foreground
 
 # httpd config has hard coded /svn for parent path, but if we declare a Volume here you can't prepare repositories in downstream images
 #VOLUME /svn
 
 RUN mkdir /svn && chown daemon /svn
+
+# Env requires wrapper entrypoint, which we abandoned in https://github.com/solsson/docker-library-httpd/tree/stretch
+# Set to "anon" to pick up username (for commit log etc) from BASIC auth header without verification of credentials
+#ENV AUTHN ""
+# Set to "svn"/"inrepo"/"admrepo", see conf/authz/options.conf
+#ENV AUTHZ ""
+# Set to "fpm" to enable rweb conf
+#ENV RWEB ""
+
+CMD [ "-DAUTHN=", "-DAUTHZ=", "-DRWEB=" ]

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM solsson/httpd-stretch
+FROM solsson/httpd-stretch@sha256:5e5359fd904cf2436b6b6811523cf3f0a0bb89eeaa62c667b6d7df901f25d06e
 
 ENV SVN_VERSION 1.8.19
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,6 +1,5 @@
 
-# https://github.com/docker-library/repo-info/blob/master/repos/httpd/tag-details.md
-FROM httpd:2.4.25@sha256:4612fba4347bd87eaeecd5c522d844f26cc4065b45eef9291277497946b7a86c
+FROM solsson/httpd-stretch
 
 ENV SVN_VERSION 1.8.19
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2

--- a/rweb/fpm-svn/Dockerfile
+++ b/rweb/fpm-svn/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1.5-fpm@sha256:2256f2bd134274434814c394002b4e11802e02aa554ef197741705d83523fd59
+FROM php:7.2.0RC6-fpm-stretch
 
 # Same build concept as in httpd,
 # but rweb should only have the svn client with http ra

--- a/rweb/fpm-svn/Dockerfile
+++ b/rweb/fpm-svn/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.0RC6-fpm-stretch
+FROM php:7.2.0-fpm-stretch@sha256:83fea692a12107c4715f2771ad2a543440abc0e2ed6a3b6282dd58623c485b5e
 
 # Same build concept as in httpd,
 # but rweb should only have the svn client with http ra

--- a/rweb/fpm-svn/Dockerfile
+++ b/rweb/fpm-svn/Dockerfile
@@ -1,10 +1,10 @@
-FROM php:7.2.5-fpm-stretch@sha256:b7542777e71ee485ff2c9ead73e70e27e83491714176ddf966af36b14e351989
+FROM php:7.2.13-fpm-stretch@sha256:da970907a1e98d4878c6a8e3bd7bedf0ff89ccaeff7e6af031836547d617c089
 
 # Same build concept as in httpd,
 # but rweb should only have the svn client with http ra
 
 ENV SVN_VERSION 1.8.19
-ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
+ENV SVN_BZ2_URL https://archive.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
 ENV SVN_BZ2_SHA1 51d7e5329ad86a650f8fc806eb68e581055a3fd1
 
 RUN buildDeps=' \

--- a/rweb/fpm-svn/Dockerfile
+++ b/rweb/fpm-svn/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.0-fpm-stretch@sha256:83fea692a12107c4715f2771ad2a543440abc0e2ed6a3b6282dd58623c485b5e
+FROM php:7.2.5-fpm-stretch@sha256:b7542777e71ee485ff2c9ead73e70e27e83491714176ddf966af36b14e351989
 
 # Same build concept as in httpd,
 # but rweb should only have the svn client with http ra

--- a/rweb/fpm/Dockerfile
+++ b/rweb/fpm/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl3 \
     libcurl4-openssl-dev \
     graphicsmagick \
+    ghostscript \
     locales \
     zlib1g-dev \
     libicu57 \

--- a/rweb/fpm/Dockerfile
+++ b/rweb/fpm/Dockerfile
@@ -1,8 +1,8 @@
 FROM solsson/fpm-svn
 
-ENV RWEB_VERSION=v1.7.3
+ENV RWEB_VERSION=v1.7.6
 ENV RWEB_TGZ_URL=https://github.com/Reposoft/rweb/archive/$RWEB_VERSION.tar.gz
-ENV RWEB_TGZ_SHA1=ce16dd26a450fe0d18bb46aaa1cb991751e82a1c
+ENV RWEB_TGZ_SHA256=a0371ca1c738f89219dc9c5ed87d08f01a92bf210ba789db830915c950359371
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates \
@@ -37,7 +37,7 @@ ADD conf.d/* /usr/local/etc/php/conf.d/
 
 RUN echo "Downloading rweb source..." \
   && curl -SLk "$RWEB_TGZ_URL" -o /usr/src/rweb-$RWEB_VERSION.tar.gz \
-  && echo "$RWEB_TGZ_SHA1 /usr/src/rweb-$RWEB_VERSION.tar.gz" | sha1sum -c - \
+  && echo "$RWEB_TGZ_SHA256 /usr/src/rweb-$RWEB_VERSION.tar.gz" | sha256sum -c - \
   && mkdir -p /usr/src/rweb \
   && tar -xf /usr/src/rweb-$RWEB_VERSION.tar.gz -C /usr/src/rweb --strip-components=1 \
   && rm /usr/src/rweb-$RWEB_VERSION.tar.gz \

--- a/rweb/fpm/Dockerfile
+++ b/rweb/fpm/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     locales \
     zlib1g-dev \
     libicu57 \
+    poppler-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/rweb/fpm/Dockerfile
+++ b/rweb/fpm/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     locales \
     zlib1g-dev \
     libicu57 \
-    poppler-utils \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/rweb/fpm/Dockerfile
+++ b/rweb/fpm/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     graphicsmagick \
     locales \
     zlib1g-dev \
-    libicu52 \
+    libicu57 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/rweb/httpd/Dockerfile
+++ b/rweb/httpd/Dockerfile
@@ -1,7 +1,5 @@
 FROM solsson/svn-httpd
 
-ENV RWEB=fpm
-
 ENV RWEB_VERSION=v1.7.3
 ENV RWEB_TGZ_URL=https://github.com/Reposoft/rweb/archive/$RWEB_VERSION.tar.gz
 ENV RWEB_TGZ_SHA1=ce16dd26a450fe0d18bb46aaa1cb991751e82a1c
@@ -21,3 +19,5 @@ RUN  sed -i 's|^#LoadModule rewrite_module|LoadModule rewrite_module|' conf/http
   && sed -i 's|^#LoadModule proxy_fcgi_module|LoadModule proxy_fcgi_module|' conf/httpd.conf \
   && mv /usr/src/rweb/test/conf-svn/rweb-services.conf conf/svn/rweb/services-fpm.conf \
   && echo "Include conf/svn/rweb/*.conf" >> conf/svn/httpd.conf
+
+CMD [ "-DAUTHN=", "-DAUTHZ=", "-DRWEB=fpm" ]

--- a/rweb/httpd/Dockerfile
+++ b/rweb/httpd/Dockerfile
@@ -1,12 +1,12 @@
 FROM solsson/svn-httpd
 
-ENV RWEB_VERSION=v1.7.3
+ENV RWEB_VERSION=v1.7.6
 ENV RWEB_TGZ_URL=https://github.com/Reposoft/rweb/archive/$RWEB_VERSION.tar.gz
-ENV RWEB_TGZ_SHA1=ce16dd26a450fe0d18bb46aaa1cb991751e82a1c
+ENV RWEB_TGZ_SHA256=a0371ca1c738f89219dc9c5ed87d08f01a92bf210ba789db830915c950359371
 
 RUN echo "Downloading rweb source..." \
   && curl -SLk "$RWEB_TGZ_URL" -o /usr/src/rweb-$RWEB_VERSION.tar.gz \
-  && echo "$RWEB_TGZ_SHA1 /usr/src/rweb-$RWEB_VERSION.tar.gz" | sha1sum -c - \
+  && echo "$RWEB_TGZ_SHA256 /usr/src/rweb-$RWEB_VERSION.tar.gz" | sha256sum -c - \
   && mkdir -p /usr/src/rweb \
   && tar -xf /usr/src/rweb-$RWEB_VERSION.tar.gz -C /usr/src/rweb --strip-components=1 \
   && rm /usr/src/rweb-$RWEB_VERSION.tar.gz \

--- a/svnclient/Dockerfile
+++ b/svnclient/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stretch-slim@sha256:6c31161e090aa3f62b9ee1414b58f0a352b42b2b7827166e57724a8662fe4b38
 
 ENV SVN_VERSION 1.8.19
-ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
+ENV SVN_BZ2_URL https://archive.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2
 ENV SVN_BZ2_SHA1 51d7e5329ad86a650f8fc806eb68e581055a3fd1
 
 RUN depsRuntime=' \

--- a/svnclient/Dockerfile
+++ b/svnclient/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:jessie@sha256:f7062cf040f67f0c26ff46b3b44fe036c29468a7e69d8170f37c57f2eec1261b
+# TODO use the same stretch-slim build that current ../rweb/fpm-svn gets
+FROM debian:stretch-slim@sha256:ea42520331a55094b90f6f6663211d4f5a62c5781673935fe17a4dfced777029
 
 ENV SVN_VERSION 1.8.19
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2

--- a/svnclient/Dockerfile
+++ b/svnclient/Dockerfile
@@ -1,5 +1,5 @@
 # TODO use the same stretch-slim build that current ../rweb/fpm-svn gets
-FROM debian:stretch-slim@sha256:ea42520331a55094b90f6f6663211d4f5a62c5781673935fe17a4dfced777029
+FROM debian:stretch-slim@sha256:6c31161e090aa3f62b9ee1414b58f0a352b42b2b7827166e57724a8662fe4b38
 
 ENV SVN_VERSION 1.8.19
 ENV SVN_BZ2_URL https://www.apache.org/dist/subversion/subversion-$SVN_VERSION.tar.bz2


### PR DESCRIPTION
... which is also what [php-fpm](https://github.com/docker-library/php/blob/2577f1147b323633d64501f1a085ce8c580ab863/7.2-rc/stretch/fpm/Dockerfile) is about to do.

Currently requires: https://github.com/solsson/docker-library-httpd/pull/1